### PR TITLE
Remove output splat syntax on nested map attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Available targets:
 | chamber_service | SSM parameter service name for use with chamber. This is used in chamber_format where /$chamber_service/$parameter would be the default. | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
 | deployment_mode | The deployment mode of the broker. Supported: SINGLE_INSTANCE and ACTIVE_STANDBY_MULTI_AZ | string | `ACTIVE_STANDBY_MULTI_AZ` | no |
-| enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | engine_type | The type of broker engine. Currently, Amazon MQ supports only ActiveMQ | string | `ActiveMQ` | no |
 | engine_version | The version of the broker engine. Currently, Amazon MQ supports only 5.15.0 or 5.15.6. | string | `5.15.0` | no |
 | general_log | Enables general logging via CloudWatch | string | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -11,7 +11,6 @@
 | chamber_service | SSM parameter service name for use with chamber. This is used in chamber_format where /$chamber_service/$parameter would be the default. | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
 | deployment_mode | The deployment mode of the broker. Supported: SINGLE_INSTANCE and ACTIVE_STANDBY_MULTI_AZ | string | `ACTIVE_STANDBY_MULTI_AZ` | no |
-| enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | engine_type | The type of broker engine. Currently, Amazon MQ supports only ActiveMQ | string | `ActiveMQ` | no |
 | engine_version | The version of the broker engine. Currently, Amazon MQ supports only 5.15.0 or 5.15.6. | string | `5.15.0` | no |
 | general_log | Enables general logging via CloudWatch | string | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -6,53 +6,45 @@ module "label" {
   delimiter  = "${var.delimiter}"
   attributes = "${var.attributes}"
   tags       = "${var.tags}"
-  enabled    = "${var.enabled}"
 }
 
 locals {
-  enabled                 = "${var.enabled == "true" ? true : false}"
   kms_key_id              = "${length(var.kms_key_id) > 0 ? var.kms_key_id : format("alias/%s-%s-chamber", var.namespace, var.stage)}"
   key_id                  = "${join("", data.aws_kms_key.chamber_kms_key.*.id)}"
   chamber_service         = "${var.chamber_service == "" ? basename(pathexpand(path.module)) : var.chamber_service}"
-  mq_admin_user           = "${length(var.mq_admin_user) > 0 ? var.mq_admin_user : join("", random_string.mq_admin_user.*.result)}"
-  mq_admin_password       = "${length(var.mq_admin_password) > 0 ? var.mq_admin_password : join("", random_string.mq_admin_password.*.result)}"
-  mq_application_user     = "${length(var.mq_application_user) > 0 ? var.mq_application_user : join("", random_string.mq_application_user.*.result)}"
-  mq_application_password = "${length(var.mq_application_password) > 0 ? var.mq_application_password : join("", random_string.mq_application_password.*.result)}"
+  mq_admin_user           = "${length(var.mq_admin_user) > 0 ? var.mq_admin_user : random_string.mq_admin_user.result}"
+  mq_admin_password       = "${length(var.mq_admin_password) > 0 ? var.mq_admin_password : random_string.mq_admin_password.result}"
+  mq_application_user     = "${length(var.mq_application_user) > 0 ? var.mq_application_user : random_string.mq_application_user.result}"
+  mq_application_password = "${length(var.mq_application_password) > 0 ? var.mq_application_password : random_string.mq_application_password.result}"
 }
 
 data "aws_kms_key" "chamber_kms_key" {
-  count  = "${var.enabled ? 1 : 0}"
   key_id = "${local.kms_key_id}"
 }
 
 resource "random_string" "mq_admin_user" {
-  count   = "${local.enabled ? 1 : 0}"
   length  = 8
   special = false
   number  = false
 }
 
 resource "random_string" "mq_admin_password" {
-  count   = "${local.enabled ? 1 : 0}"
   length  = 16
   special = false
 }
 
 resource "random_string" "mq_application_user" {
-  count   = "${local.enabled ? 1 : 0}"
   length  = 8
   special = false
   number  = false
 }
 
 resource "random_string" "mq_application_password" {
-  count   = "${local.enabled ? 1 : 0}"
   length  = 16
   special = false
 }
 
 resource "aws_ssm_parameter" "mq_master_username" {
-  count       = "${local.enabled ? 1 : 0}"
   name        = "${format(var.chamber_parameter_name, local.chamber_service, "mq_admin_username")}"
   value       = "${local.mq_admin_user}"
   description = "MQ Username for the master user"
@@ -61,7 +53,6 @@ resource "aws_ssm_parameter" "mq_master_username" {
 }
 
 resource "aws_ssm_parameter" "mq_master_password" {
-  count       = "${local.enabled ? 1 : 0}"
   name        = "${format(var.chamber_parameter_name, local.chamber_service, "mq_admin_password")}"
   value       = "${local.mq_admin_password}"
   description = "MQ Password for the master user"
@@ -71,7 +62,6 @@ resource "aws_ssm_parameter" "mq_master_password" {
 }
 
 resource "aws_ssm_parameter" "mq_application_username" {
-  count       = "${local.enabled ? 1 : 0}"
   name        = "${format(var.chamber_parameter_name, local.chamber_service, "mq_application_username")}"
   value       = "${local.mq_application_user}"
   description = "AMQ username for the application user"
@@ -80,7 +70,6 @@ resource "aws_ssm_parameter" "mq_application_username" {
 }
 
 resource "aws_ssm_parameter" "mq_application_password" {
-  count       = "${local.enabled ? 1 : 0}"
   name        = "${format(var.chamber_parameter_name, local.chamber_service, "mq_application_password")}"
   value       = "${local.mq_application_password}"
   description = "AMQ password for the application user"
@@ -90,7 +79,6 @@ resource "aws_ssm_parameter" "mq_application_password" {
 }
 
 resource "aws_mq_broker" "default" {
-  count                      = "${local.enabled ? 1 : 0}"
   broker_name                = "${module.label.id}"
   deployment_mode            = "${var.deployment_mode}"
   engine_type                = "${var.engine_type}"
@@ -127,18 +115,17 @@ resource "aws_mq_broker" "default" {
 }
 
 resource "aws_security_group" "default" {
-  count  = "${local.enabled ? 1 : 0}"
   vpc_id = "${var.vpc_id}"
   name   = "${module.label.id}"
   tags   = "${module.label.tags}"
 }
 
 resource "aws_security_group_rule" "default" {
-  count                    = "${local.enabled && length(var.security_groups) > 0 ? length(var.security_groups) : 0}"
+  count                    = "${length(var.security_groups) > 0 ? length(var.security_groups) : 0}"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = "0"
   to_port                  = "0"
   source_security_group_id = "${element(var.security_groups, count.index)}"
-  security_group_id        = "${join("", aws_security_group.default.*.id)}"
+  security_group_id        = "${aws_security_group.default.id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,72 +9,72 @@ output "broker_arn" {
 }
 
 output "primary_console_url" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.0.console_url, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.0.console_url}"
   description = "AmazonMQ active web console URL"
 }
 
 output "primary_ssl_endpoint" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.0.endpoints.0, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.0.endpoints.0}"
   description = "AmazonMQ primary SSL endpoint"
 }
 
 output "primary_amqp_ssl_endpoint" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.0.endpoints.1, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.0.endpoints.1}"
   description = "AmazonMQ primary AMQP+SSL endpoint"
 }
 
 output "primary_stomp_ssl_endpoint" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.0.endpoints.2, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.0.endpoints.2}"
   description = "AmazonMQ primary STOMP+SSL endpoint"
 }
 
 output "primary_mqtt_ssl_endpoint" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.0.endpoints.3, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.0.endpoints.3}"
   description = "AmazonMQ primary MQTT+SSL endpoint"
 }
 
 output "primary_wss_endpoint" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.0.endpoints.4, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.0.endpoints.4}"
   description = "AmazonMQ primary WSS endpoint"
 }
 
 output "primary_ip_address" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.0.ip_address, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.0.ip_address}"
   description = "AmazonMQ primary IP address"
 }
 
 output "secondary_console_url" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.1.console_url, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.1.console_url}"
   description = "AmazonMQ secondary web console URL"
 }
 
 output "secondary_ssl_endpoint" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.1.endpoints.0, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.1.endpoints.0}"
   description = "AmazonMQ secondary SSL endpoint"
 }
 
 output "secondary_amqp_ssl_endpoint" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.1.endpoints.1, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.1.endpoints.1}"
   description = "AmazonMQ secondary AMQP+SSL endpoint"
 }
 
 output "secondary_stomp_ssl_endpoint" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.1.endpoints.2, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.1.endpoints.2}"
   description = "AmazonMQ secondary STOMP+SSL endpoint"
 }
 
 output "secondary_mqtt_ssl_endpoint" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.1.endpoints.3, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.1.endpoints.3}"
   description = "AmazonMQ secondary MQTT+SSL endpoint"
 }
 
 output "secondary_wss_endpoint" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.1.endpoints.4, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.1.endpoints.4}"
   description = "AmazonMQ secondary WSS endpoint"
 }
 
 output "secondary_ip_address" {
-  value       = "${element(concat(aws_mq_broker.default.*.instances.1.ip_address, list("")), 0)}"
+  value       = "${aws_mq_broker.default.instances.1.ip_address}"
   description = "AmazonMQ secondary IP address"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,12 +4,6 @@ variable "apply_immediately" {
   description = "Specifies whether any cluster modifications are applied immediately, or during the next maintenance window"
 }
 
-variable "enabled" {
-  type        = "string"
-  default     = "true"
-  description = "Set to false to prevent the module from creating any resources"
-}
-
 variable "auto_minor_version_upgrade" {
   type        = "string"
   default     = "false"


### PR DESCRIPTION
When initially building this module, it was done piece meal adding the
outputs once the initial apply had been done. apply/plan etc all looked
good after the initial apply. However, there is a bug whereby the splat
output fails when dealing with nested map attributes[1]. This issue was
raised by @igor when an initial plan/apply fails as the below example:

```
module.amq.output.primary_console_url: Resource 'aws_mq_broker.default' does not have attribute 'instances.0.console_url' for variable 'aws_mq_broker.default.*.instances.0.console_url'
```

Removing the splat style syntax resolved this issue, but the splat was
necessary due to the `count` (read: enabled flag) on the `aws_mq_broker`
resource. This “fix” works when `enabled = “true”` but fails when 
`enabled = “false”` as this ends up with a 0 count. It seems that trying
to use the splat syntax and asking for nested attributes (conditionally)
is not possible in current terraform. I think we likely have this issue
in other Terraform modules but don’t hit it as do not often set 
`enabled = “false”`

[1] https://github.com/hashicorp/terraform/issues/17048