### PR TITLE
create random username and password for admin user only if needed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,14 +16,14 @@ locals {
 }
 
 resource "random_string" "mq_admin_user" {
-  count   = local.enabled && ! local.mq_admin_user_is_set ? 1 : 0
+  count   = local.enabled && local.mq_admin_user_enabled && ! local.mq_admin_user_is_set ? 1 : 0
   length  = 8
   special = false
   number  = false
 }
 
 resource "random_password" "mq_admin_password" {
-  count   = local.enabled && ! local.mq_admin_password_is_set ? 1 : 0
+  count   = local.enabled && local.mq_admin_user_enabled && ! local.mq_admin_password_is_set ? 1 : 0
   length  = 16
   special = false
 }


### PR DESCRIPTION
## what
* only create random strings for admin user and admin password, if we are actually going to use them
* the logic is that only if the module is enabled, and the admin user is enabled and if the admin user was not passed in (i.e. is unset) only then do we need to create these random strings

## why
* the admin user is a dynamic property and it does NOT get created, if admin user is not enabled
* we do not need to create these random strings when the dynamic block does not created
* since the admin user is a dynamic block, we do NOT need to worry about username and password being required fields 
* They are not required because the whole block won't exist

## references
* follow up for https://github.com/cloudposse/terraform-aws-mq-broker/commit/867068d24ba43fd583c3d06ad69c84720204c84d
