### PR TITLE
add `tags` argument to aws_ssm_parameter resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ resource "aws_ssm_parameter" "mq_master_username" {
   description = "MQ Username for the admin user"
   type        = "String"
   overwrite   = var.overwrite_ssm_parameter
+  tags        = module.this.tags
 }
 
 resource "aws_ssm_parameter" "mq_master_password" {
@@ -58,6 +59,7 @@ resource "aws_ssm_parameter" "mq_master_password" {
   type        = "SecureString"
   key_id      = var.kms_ssm_key_arn
   overwrite   = var.overwrite_ssm_parameter
+  tags        = module.this.tags
 }
 
 resource "aws_ssm_parameter" "mq_application_username" {
@@ -67,6 +69,7 @@ resource "aws_ssm_parameter" "mq_application_username" {
   description = "AMQ username for the application user"
   type        = "String"
   overwrite   = var.overwrite_ssm_parameter
+  tags        = module.this.tags
 }
 
 resource "aws_ssm_parameter" "mq_application_password" {
@@ -77,6 +80,7 @@ resource "aws_ssm_parameter" "mq_application_password" {
   type        = "SecureString"
   key_id      = var.kms_ssm_key_arn
   overwrite   = var.overwrite_ssm_parameter
+  tags        = module.this.tags
 }
 
 resource "aws_mq_broker" "default" {


### PR DESCRIPTION
## what
* Add `tags` argument to `aws_ssm_parameter` resources.

## why
* Testing Terraform code often involves adhering to compliance standards.  In this case I have a compliance requirement to include certain tags on all resources that accept the `tags` argument.

## references
* https://terraform-compliance.com/pages/Examples/tags_related.html
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter#tags

