### PR TITLE
Dynamic logs block

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 This module provisions the following resources:
   - ActiveMQ broker
+  - RabbitMQ broker
   - Security group rules to allow access to the broker
 
 Admin and application users are created and credentials written to SSM if not passed in as variables.

--- a/README.yaml
+++ b/README.yaml
@@ -53,6 +53,7 @@ description: |-
 introduction: |-
   This module provisions the following resources:
     - ActiveMQ broker
+    - RabbitMQ broker
     - Security group rules to allow access to the broker
 
   Admin and application users are created and credentials written to SSM if not passed in as variables.

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ locals {
 
   mq_application_password_is_set = var.mq_application_password != null && var.mq_application_password != ""
   mq_application_password        = local.mq_application_password_is_set ? var.mq_application_password : join("", random_password.mq_application_password.*.result)
-  mq_logs = {logs = {"general_log_enabled": var.general_log_enabled, "audit_log_enabled": var.audit_log_enabled}}
+  mq_logs                        = { logs = { "general_log_enabled" : var.general_log_enabled, "audit_log_enabled" : var.audit_log_enabled } }
 }
 
 resource "random_string" "mq_admin_user" {

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ locals {
 
   mq_application_password_is_set = var.mq_application_password != null && var.mq_application_password != ""
   mq_application_password        = local.mq_application_password_is_set ? var.mq_application_password : join("", random_password.mq_application_password.*.result)
+  mq_logs = {"general_log_enabled": var.general_log_enabled, "audit_log_enabled": var.audit_log_enabled}
 }
 
 resource "random_string" "mq_admin_user" {
@@ -105,9 +106,12 @@ resource "aws_mq_broker" "default" {
     }
   }
 
-  logs {
-    general = var.general_log_enabled
-    audit   = var.audit_log_enabled
+  dynamic "logs" {
+    for_each = var.engine_type == "RabbitMQ" ? {} : { logs = local.mq_logs }
+    content {
+      general = logs.value["general_log_enabled"]
+      audit   = logs.value["audit_log_enabled"]
+    }
   }
 
   maintenance_window_start_time {

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ locals {
 
   mq_application_password_is_set = var.mq_application_password != null && var.mq_application_password != ""
   mq_application_password        = local.mq_application_password_is_set ? var.mq_application_password : join("", random_password.mq_application_password.*.result)
-  mq_logs = {"general_log_enabled": var.general_log_enabled, "audit_log_enabled": var.audit_log_enabled}
+  mq_logs = {logs = {"general_log_enabled": var.general_log_enabled, "audit_log_enabled": var.audit_log_enabled}}
 }
 
 resource "random_string" "mq_admin_user" {
@@ -106,8 +106,13 @@ resource "aws_mq_broker" "default" {
     }
   }
 
+  # NOTE: Omit logs block if both general and audit logs disabled:
+  # https://github.com/hashicorp/terraform-provider-aws/issues/18067
   dynamic "logs" {
-    for_each = var.engine_type == "RabbitMQ" ? {} : { logs = local.mq_logs }
+    for_each = {
+      for logs, type in local.mq_logs : logs => type
+      if type.general_log_enabled || type.audit_log_enabled
+    }
     content {
       general = logs.value["general_log_enabled"]
       audit   = logs.value["audit_log_enabled"]


### PR DESCRIPTION
## what
- RabbitMQ support via dynamic `logs` block
  - RabbitMQ general logs cannot be enabled.
    - https://github.com/hashicorp/terraform-provider-aws/issues/18067

## why
- Support `engine_type = "RabbitMQ"`

## references
- https://github.com/hashicorp/terraform-provider-aws/issues/18067
* Closes https://github.com/cloudposse/terraform-aws-mq-broker/issues/24 insofar as the provider doesn't currently support enabling general logging at this time.
* I think https://github.com/cloudposse/terraform-aws-mq-broker/issues/18 can also be closed.

