### PR TITLE
fix ingress security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!-- markdownlint-disable -->
 # terraform-aws-mq-broker [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-mq-broker.svg)](https://github.com/cloudposse/terraform-aws-mq-broker/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 <!-- markdownlint-restore -->
@@ -29,7 +30,6 @@
 
 Terraform module to provision AmazonMQ resources on AWS
 
-
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
@@ -59,7 +59,6 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 
 
-
 ## Introduction
 
 This module provisions the following resources:
@@ -68,6 +67,7 @@ This module provisions the following resources:
   - Security group rules to allow access to the broker
 
 Admin and application users are created and credentials written to SSM if not passed in as variables.
+
 
 ## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Available targets:
 | <a name="output_secondary_ssl_endpoint"></a> [secondary\_ssl\_endpoint](#output\_secondary\_ssl\_endpoint) | AmazonMQ secondary SSL endpoint |
 | <a name="output_secondary_stomp_ssl_endpoint"></a> [secondary\_stomp\_ssl\_endpoint](#output\_secondary\_stomp\_ssl\_endpoint) | AmazonMQ secondary STOMP+SSL endpoint |
 | <a name="output_secondary_wss_endpoint"></a> [secondary\_wss\_endpoint](#output\_secondary\_wss\_endpoint) | AmazonMQ secondary WSS endpoint |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The security group created by this module. |
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -111,4 +111,5 @@
 | <a name="output_secondary_ssl_endpoint"></a> [secondary\_ssl\_endpoint](#output\_secondary\_ssl\_endpoint) | AmazonMQ secondary SSL endpoint |
 | <a name="output_secondary_stomp_ssl_endpoint"></a> [secondary\_stomp\_ssl\_endpoint](#output\_secondary\_stomp\_ssl\_endpoint) | AmazonMQ secondary STOMP+SSL endpoint |
 | <a name="output_secondary_wss_endpoint"></a> [secondary\_wss\_endpoint](#output\_secondary\_wss\_endpoint) | AmazonMQ secondary WSS endpoint |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The security group created by this module. |
 <!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ locals {
   mq_application_password        = local.mq_application_password_is_set ? var.mq_application_password : join("", random_password.mq_application_password.*.result)
 
   mq_logs  = { logs = { "general_log_enabled" : var.general_log_enabled, "audit_log_enabled" : var.audit_log_enabled } }
-  mq_ports = var.engine_type == "ActiveMQ" ? [ 8162, 61617 ] : [ 443, 5671 ]
+  mq_ports = var.engine_type == "ActiveMQ" ? [8162, 61617] : [443, 5671]
 
   mq_security_ports = [
     for pair in setproduct(var.allowed_security_groups, local.mq_ports) : {

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,23 @@ locals {
 
   mq_application_password_is_set = var.mq_application_password != null && var.mq_application_password != ""
   mq_application_password        = local.mq_application_password_is_set ? var.mq_application_password : join("", random_password.mq_application_password.*.result)
-  mq_logs                        = { logs = { "general_log_enabled" : var.general_log_enabled, "audit_log_enabled" : var.audit_log_enabled } }
+
+  mq_logs  = { logs = { "general_log_enabled" : var.general_log_enabled, "audit_log_enabled" : var.audit_log_enabled } }
+  mq_ports = var.engine_type == "ActiveMQ" ? [ 8162, 61617 ] : [ 443, 5671 ]
+
+  mq_security_ports = [
+    for pair in setproduct(var.allowed_security_groups, local.mq_ports) : {
+      security_group_id = pair[0]
+      port              = pair[1]
+    }
+  ]
+
+  mq_cidr_ports = [
+    for pair in setproduct(var.allowed_cidr_blocks, local.mq_ports) : {
+      cidr = pair[0]
+      port = pair[1]
+    }
+  ]
 }
 
 resource "random_string" "mq_admin_user" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "broker_arn" {
   description = "AmazonMQ broker ARN"
 }
 
+output "security_group_id" {
+  value       = var.use_existing_security_groups ? null : aws_security_group.default.0.id
+  description = "The security group created by this module."
+}
+
 output "primary_console_url" {
   value       = try(aws_mq_broker.default[0].instances[0].console_url, "")
   description = "AmazonMQ active web console URL"

--- a/sg.tf
+++ b/sg.tf
@@ -20,8 +20,8 @@ resource "aws_security_group_rule" "ingress_security_groups" {
   count                    = module.this.enabled && var.use_existing_security_groups == false ? length(var.allowed_security_groups) : 0
   description              = "Allow inbound traffic from existing Security Groups"
   from_port                = 0
-  to_port                  = 0
-  protocol                 = "tcp"
+  to_port                  = 65535
+  protocol                 = "-1"
   source_security_group_id = var.allowed_security_groups[count.index]
   security_group_id        = join("", aws_security_group.default.*.id)
   type                     = "ingress"
@@ -30,9 +30,9 @@ resource "aws_security_group_rule" "ingress_security_groups" {
 resource "aws_security_group_rule" "ingress_cidr_blocks" {
   count             = module.this.enabled && var.use_existing_security_groups == false && length(var.allowed_cidr_blocks) > 0 ? 1 : 0
   description       = "Allow inbound traffic from CIDR blocks"
-  from_port         = "0"
-  to_port           = "0"
-  protocol          = "tcp"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "-1"
   cidr_blocks       = var.allowed_cidr_blocks
   security_group_id = join("", aws_security_group.default.*.id)
   type              = "ingress"

--- a/sg.tf
+++ b/sg.tf
@@ -17,23 +17,29 @@ resource "aws_security_group_rule" "egress" {
 }
 
 resource "aws_security_group_rule" "ingress_security_groups" {
-  count                    = module.this.enabled && var.use_existing_security_groups == false ? length(var.allowed_security_groups) : 0
+  for_each = module.this.enabled && var.use_existing_security_groups == false ? {
+    for port in local.mq_security_ports : "${port.security_group_id}.${port.port}" => port
+  } : {}
+
   description              = "Allow inbound traffic from existing Security Groups"
-  from_port                = 0
-  to_port                  = 65535
-  protocol                 = "-1"
-  source_security_group_id = var.allowed_security_groups[count.index]
+  from_port                = each.value.port
+  to_port                  = each.value.port
+  protocol                 = "tcp"
+  source_security_group_id = each.value.security_group_id
   security_group_id        = join("", aws_security_group.default.*.id)
   type                     = "ingress"
 }
 
 resource "aws_security_group_rule" "ingress_cidr_blocks" {
-  count             = module.this.enabled && var.use_existing_security_groups == false && length(var.allowed_cidr_blocks) > 0 ? 1 : 0
+  for_each = module.this.enabled && var.use_existing_security_groups == false ? {
+    for port in local.mq_cidr_ports : "${port.cidr}.${port.port}" => port
+  } : {}
+
   description       = "Allow inbound traffic from CIDR blocks"
-  from_port         = 0
-  to_port           = 65535
-  protocol          = "-1"
-  cidr_blocks       = var.allowed_cidr_blocks
+  from_port         = each.value.port
+  to_port           = each.value.port
+  protocol          = "tcp"
+  cidr_blocks       = [each.value.cidr]
   security_group_id = join("", aws_security_group.default.*.id)
   type              = "ingress"
 }


### PR DESCRIPTION
## what
* fix ingress security groups
* if this module creates the security group then output the security_group_id

## why
* Having protocol set to "tcp" will set the to/from ports
  to the "0" specified.  Port 0 is not an ActiveMQ or
  RabbitMQ broker port.  Instead, use appropriate ActiveMQ or RabbitMQ ports
  per allowed_security_groups and allowed_cidr_blocks.

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule
* Closes https://github.com/cloudposse/terraform-aws-mq-broker/issues/29
