### PR TITLE
Add variables so we can add custom names for ssm parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Available targets:
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of Security Group IDs to associate with AmazonMQ. | `list(string)` | `[]` | no |
 | <a name="input_ssm_parameter_name_format"></a> [ssm\_parameter\_name\_format](#input\_ssm\_parameter\_name\_format) | SSM parameter name format | `string` | `"/%s/%s"` | no |
 | <a name="input_ssm_path"></a> [ssm\_path](#input\_ssm\_path) | SSM path | `string` | `"mq"` | no |
+| <a name="input_ssm_parameter_name_username"></a> [ssm_parameter_name_username](#input\_ssm_parameter_name_username) | SSM parameter name for admin username, excluding path | `string` | `mq_admin_username` | no |
+| <a name="input_ssm_parameter_name_password"></a> [ssm_parameter_name_password](#input\_ssm_parameter_name_password) | SSM parameter name for admin password, excluding path | `string` | `mq_admin_password` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of VPC subnet IDs | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -233,9 +233,9 @@ Available targets:
 | <a name="input_security_group_use_name_prefix"></a> [security\_group\_use\_name\_prefix](#input\_security\_group\_use\_name\_prefix) | Whether to create a default Security Group with unique name beginning with the normalized prefix. | `bool` | `false` | no |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of Security Group IDs to associate with AmazonMQ. | `list(string)` | `[]` | no |
 | <a name="input_ssm_parameter_name_format"></a> [ssm\_parameter\_name\_format](#input\_ssm\_parameter\_name\_format) | SSM parameter name format | `string` | `"/%s/%s"` | no |
+| <a name="input_ssm_parameter_name_password"></a> [ssm\_parameter\_name\_password](#input\_ssm\_parameter\_name\_password) | SSM parameter name for admin password | `string` | `"mq_admin_password"` | no |
+| <a name="input_ssm_parameter_name_username"></a> [ssm\_parameter\_name\_username](#input\_ssm\_parameter\_name\_username) | SSM parameter name for admin username | `string` | `"mq_admin_username"` | no |
 | <a name="input_ssm_path"></a> [ssm\_path](#input\_ssm\_path) | SSM path | `string` | `"mq"` | no |
-| <a name="input_ssm_parameter_name_username"></a> [ssm_parameter_name_username](#input\_ssm_parameter_name_username) | SSM parameter name for admin username, excluding path | `string` | `mq_admin_username` | no |
-| <a name="input_ssm_parameter_name_password"></a> [ssm_parameter_name_password](#input\_ssm_parameter_name_password) | SSM parameter name for admin password, excluding path | `string` | `mq_admin_password` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of VPC subnet IDs | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -80,6 +80,8 @@
 | <a name="input_security_group_use_name_prefix"></a> [security\_group\_use\_name\_prefix](#input\_security\_group\_use\_name\_prefix) | Whether to create a default Security Group with unique name beginning with the normalized prefix. | `bool` | `false` | no |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of Security Group IDs to associate with AmazonMQ. | `list(string)` | `[]` | no |
 | <a name="input_ssm_parameter_name_format"></a> [ssm\_parameter\_name\_format](#input\_ssm\_parameter\_name\_format) | SSM parameter name format | `string` | `"/%s/%s"` | no |
+| <a name="input_ssm_parameter_name_password"></a> [ssm\_parameter\_name\_password](#input\_ssm\_parameter\_name\_password) | SSM parameter name for admin password | `string` | `"mq_admin_password"` | no |
+| <a name="input_ssm_parameter_name_username"></a> [ssm\_parameter\_name\_username](#input\_ssm\_parameter\_name\_username) | SSM parameter name for admin username | `string` | `"mq_admin_username"` | no |
 | <a name="input_ssm_path"></a> [ssm\_path](#input\_ssm\_path) | SSM path | `string` | `"mq"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of VPC subnet IDs | `list(string)` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "random_password" "mq_application_password" {
 
 resource "aws_ssm_parameter" "mq_master_username" {
   count       = local.enabled && local.mq_admin_user_enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, "mq_admin_username")
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.ssm_parameter_name_username)
   value       = local.mq_admin_user
   description = "MQ Username for the admin user"
   type        = "String"
@@ -56,7 +56,7 @@ resource "aws_ssm_parameter" "mq_master_username" {
 
 resource "aws_ssm_parameter" "mq_master_password" {
   count       = local.enabled && local.mq_admin_user_enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, "mq_admin_password")
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.ssm_parameter_name_password)
   value       = local.mq_admin_password
   description = "MQ Password for the admin user"
   type        = "SecureString"

--- a/variables.tf
+++ b/variables.tf
@@ -159,6 +159,18 @@ variable "ssm_parameter_name_format" {
   description = "SSM parameter name format"
 }
 
+variable "ssm_parameter_name_username" {
+  type        = string
+  default     = "mq_admin_username"
+  description = "SSM parameter name for admin username"
+}
+
+variable "ssm_parameter_name_password" {
+  type        = string
+  default     = "mq_admin_password"
+  description = "SSM parameter name for admin password"
+}
+
 variable "ssm_path" {
   type        = string
   default     = "mq"


### PR DESCRIPTION
## what
This simply adds the possibility to have different name for the SSM parameters.
At the moment the defaults are:
```
/RabbitMq/mq_application_username
/RabbitMq/mq_application_password
```
we'd like to have :
```
/RabbitMq/Username
/RabbitMq/Password
```

## why
It adds more flexibility. For us, it's simpler to change the param name, than modify in all repos which use this.

