### PR TITLE
fix: set security_group_enabled false when publicly_accessible is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -15,31 +15,31 @@ locals {
   mq_application_password        = local.mq_application_password_is_set ? var.mq_application_password : join("", random_password.mq_application_password.*.result)
   mq_logs                        = { logs = { "general_log_enabled" : var.general_log_enabled, "audit_log_enabled" : var.audit_log_enabled } }
 
-  security_group_enabled = module.this.enabled && var.security_group_enabled
+  security_group_enabled = var.publicly_accessible == true ? false : module.this.enabled && var.security_group_enabled
 }
 
 resource "random_string" "mq_admin_user" {
-  count   = local.enabled && local.mq_admin_user_enabled && ! local.mq_admin_user_is_set ? 1 : 0
+  count   = local.enabled && local.mq_admin_user_enabled && !local.mq_admin_user_is_set ? 1 : 0
   length  = 8
   special = false
   number  = false
 }
 
 resource "random_password" "mq_admin_password" {
-  count   = local.enabled && local.mq_admin_user_enabled && ! local.mq_admin_password_is_set ? 1 : 0
+  count   = local.enabled && local.mq_admin_user_enabled && !local.mq_admin_password_is_set ? 1 : 0
   length  = 16
   special = false
 }
 
 resource "random_string" "mq_application_user" {
-  count   = local.enabled && ! local.mq_application_user_is_set ? 1 : 0
+  count   = local.enabled && !local.mq_application_user_is_set ? 1 : 0
   length  = 8
   special = false
   number  = false
 }
 
 resource "random_password" "mq_application_password" {
-  count   = local.enabled && ! local.mq_application_password_is_set ? 1 : 0
+  count   = local.enabled && !local.mq_application_password_is_set ? 1 : 0
   length  = 16
   special = false
 }

--- a/main.tf
+++ b/main.tf
@@ -19,27 +19,27 @@ locals {
 }
 
 resource "random_string" "mq_admin_user" {
-  count   = local.enabled && local.mq_admin_user_enabled && !local.mq_admin_user_is_set ? 1 : 0
+  count   = local.enabled && local.mq_admin_user_enabled && ! local.mq_admin_user_is_set ? 1 : 0
   length  = 8
   special = false
   number  = false
 }
 
 resource "random_password" "mq_admin_password" {
-  count   = local.enabled && local.mq_admin_user_enabled && !local.mq_admin_password_is_set ? 1 : 0
+  count   = local.enabled && local.mq_admin_user_enabled && ! local.mq_admin_password_is_set ? 1 : 0
   length  = 16
   special = false
 }
 
 resource "random_string" "mq_application_user" {
-  count   = local.enabled && !local.mq_application_user_is_set ? 1 : 0
+  count   = local.enabled && ! local.mq_application_user_is_set ? 1 : 0
   length  = 8
   special = false
   number  = false
 }
 
 resource "random_password" "mq_application_password" {
-  count   = local.enabled && !local.mq_application_password_is_set ? 1 : 0
+  count   = local.enabled && ! local.mq_application_password_is_set ? 1 : 0
   length  = 16
   special = false
 }


### PR DESCRIPTION
## what
Added a condition to security_group_enabled variable to avoid issues when a broker is created using publicly_accessible true.
By default security_group_enabled  is set to true and if you try to create a public broker, you cannot create a security group.

│   Message_: "Broker with [publiclyAccessible] set to true does not support specifying [securityGroups]"

## why
This PR was made to avoid a less-experienced when creating a public broker.

## references

Terraform error:
│   Message_: "Broker with [publiclyAccessible] set to true does not support specifying [securityGroups]"
