### PR TITLE
Updating sg egress to use input variable

### DIFF
--- a/sg.tf
+++ b/sg.tf
@@ -62,7 +62,7 @@ module "security_group" {
   security_group_delete_timeout = var.security_group_delete_timeout
 
   security_group_description = var.security_group_description
-  allow_all_egress           = true
+  allow_all_egress           = var.allow_all_egress
   rules                      = var.additional_security_group_rules
   rule_matrix                = local.sg_rule_matrix
   vpc_id                     = var.vpc_id


### PR DESCRIPTION
## what
Egress was hardcoded to true when there was an input for it.

## why
Full egress is not always warranted. 

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

