### PR TITLE
add support for custom config and additional users

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,12 @@ resource "random_password" "mq_application_password" {
   special = false
 }
 
+resource "random_password" "mq_additional_users_password" {
+  for_each = { for user in var.mq_additional_users : user.name => user if lookup(user, "password", null) == null }
+  length   = 24
+  special  = false
+}
+
 resource "aws_ssm_parameter" "mq_master_username" {
   count       = local.mq_admin_user_enabled ? 1 : 0
   name        = format(var.ssm_parameter_name_format, var.ssm_path, var.mq_admin_user_ssm_parameter_name)
@@ -80,6 +86,27 @@ resource "aws_ssm_parameter" "mq_application_password" {
   name        = format(var.ssm_parameter_name_format, var.ssm_path, var.mq_application_password_ssm_parameter_name)
   value       = local.mq_application_password
   description = "AMQ password for the application user"
+  type        = "SecureString"
+  key_id      = var.kms_ssm_key_arn
+  overwrite   = var.overwrite_ssm_parameter
+  tags        = module.this.tags
+}
+
+resource "aws_ssm_parameter" "mq_additional_users" {
+  for_each    = { for user in var.mq_additional_users : user.name => user }
+  name        = format(var.ssm_additional_users_parameter_name_format, var.ssm_path, "mq_additional_users", each.value.name)
+  value       = each.value.name
+  description = "AMQ username for the ${each.value.name} user"
+  type        = "String"
+  overwrite   = var.overwrite_ssm_parameter
+  tags        = module.this.tags
+}
+
+resource "aws_ssm_parameter" "mq_additional_users_password" {
+  for_each    = { for user in var.mq_additional_users : user.name => user }
+  name        = format(var.ssm_additional_users_parameter_name_format, var.ssm_path, "mq_additional_user_password", each.value.name)
+  value       = lookup(each.value, "password", null) == null ? random_password.mq_additional_users_password[each.value.name].result : each.value.password
+  description = "AMQ password for the ${each.value.name} user"
   type        = "SecureString"
   key_id      = var.kms_ssm_key_arn
   overwrite   = var.overwrite_ssm_parameter
@@ -138,8 +165,38 @@ resource "aws_mq_broker" "default" {
     }
   }
 
+  dynamic "user" {
+    for_each = { for user in var.mq_additional_users : user.name => user }
+    content {
+      username       = user.value.name
+      password       = lookup(user.value, "password", null) == null ? random_password.mq_additional_users_password[user.value.name].result : user.value.password
+      groups         = user.value.groups
+      console_access = lookup(user.value, "console_access", false)
+    }
+  }
+
   user {
     username = local.mq_application_user
     password = local.mq_application_password
   }
+
+  dynamic "configuration" {
+    for_each = { for config in var.mq_configuration : config.name => config }
+    content {
+      id       = aws_mq_configuration.this[configuration.value.name].id
+      revision = aws_mq_configuration.this[configuration.value.name].latest_revision
+    }
+  }
 }
+
+resource "aws_mq_configuration" "this" {
+  for_each                = { for config in var.mq_configuration : config.name => config }
+  data                    = each.value.data
+  engine_type             = var.engine_type
+  engine_version          = var.engine_version
+  name                    = each.value.name
+  authentication_strategy = lookup(each.value, "authentication_strategy", null)
+  description             = lookup(each.value, "description", "Custom MQ configuration")
+  tags                    = module.this.tags
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -88,6 +88,12 @@ output "application_username" {
   description = "AmazonMQ application username"
 }
 
+output "additional_usernames" {
+  #value       = { for user in var.mq_additional_users : user.name => user }
+  value       = [for user in var.mq_additional_users : user.name]
+  description = "AmazonMQ additional users usernames"
+}
+
 output "security_group_id" {
   value       = module.security_group.id
   description = "The ID of the created security group"

--- a/variables.tf
+++ b/variables.tf
@@ -183,3 +183,22 @@ variable "allowed_ingress_ports" {
     EOT
   default     = []
 }
+
+variable "mq_additional_users" {
+  type        = list(any)
+  description = "Additional MQ users"
+  default     = []
+}
+
+variable "ssm_additional_users_parameter_name_format" {
+  type        = string
+  description = "SSM parameter name format"
+  default     = "/%s/%s/%s"
+}
+
+variable "mq_configuration" {
+  type        = list(any)
+  description = "Custom MQ configuration"
+  default     = []
+}
+


### PR DESCRIPTION
## what
* Add support for custom MQ configuration
* Add support for setting up additional MQ users

## why
* Custom MQ configuration was needed for the project
* Additional users were needed for the project

Full backward compatibility. Nothing will change if variables mq_additional_users or mq_configuration are undefined.