### PR TITLE
Add broker name to SSM path

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "random_password" "mq_application_password" {
 
 resource "aws_ssm_parameter" "mq_master_username" {
   count       = local.mq_admin_user_enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.name, var.mq_admin_user_ssm_parameter_name)
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, "${var.name}/${var.mq_admin_user_ssm_parameter_name}")
   value       = local.mq_admin_user
   description = "MQ Username for the admin user"
   type        = "String"
@@ -56,7 +56,7 @@ resource "aws_ssm_parameter" "mq_master_username" {
 
 resource "aws_ssm_parameter" "mq_master_password" {
   count       = local.mq_admin_user_enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.name, var.mq_admin_password_ssm_parameter_name)
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, "${var.name}/${var.mq_admin_password_ssm_parameter_name}")
   value       = local.mq_admin_password
   description = "MQ Password for the admin user"
   type        = "SecureString"
@@ -67,7 +67,7 @@ resource "aws_ssm_parameter" "mq_master_password" {
 
 resource "aws_ssm_parameter" "mq_application_username" {
   count       = local.enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.name, var.mq_application_user_ssm_parameter_name)
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, "${var.name}/${var.mq_application_user_ssm_parameter_name}")
   value       = local.mq_application_user
   description = "AMQ username for the application user"
   type        = "String"
@@ -77,7 +77,7 @@ resource "aws_ssm_parameter" "mq_application_username" {
 
 resource "aws_ssm_parameter" "mq_application_password" {
   count       = local.enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.name, var.mq_application_password_ssm_parameter_name)
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, "${var.name}/${var.mq_application_password_ssm_parameter_name}")
   value       = local.mq_application_password
   description = "AMQ password for the application user"
   type        = "SecureString"

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "random_password" "mq_application_password" {
 
 resource "aws_ssm_parameter" "mq_master_username" {
   count       = local.mq_admin_user_enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.mq_admin_user_ssm_parameter_name)
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.name, var.mq_admin_user_ssm_parameter_name)
   value       = local.mq_admin_user
   description = "MQ Username for the admin user"
   type        = "String"
@@ -56,7 +56,7 @@ resource "aws_ssm_parameter" "mq_master_username" {
 
 resource "aws_ssm_parameter" "mq_master_password" {
   count       = local.mq_admin_user_enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.mq_admin_password_ssm_parameter_name)
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.name, var.mq_admin_password_ssm_parameter_name)
   value       = local.mq_admin_password
   description = "MQ Password for the admin user"
   type        = "SecureString"
@@ -67,7 +67,7 @@ resource "aws_ssm_parameter" "mq_master_password" {
 
 resource "aws_ssm_parameter" "mq_application_username" {
   count       = local.enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.mq_application_user_ssm_parameter_name)
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.name, var.mq_application_user_ssm_parameter_name)
   value       = local.mq_application_user
   description = "AMQ username for the application user"
   type        = "String"
@@ -77,7 +77,7 @@ resource "aws_ssm_parameter" "mq_application_username" {
 
 resource "aws_ssm_parameter" "mq_application_password" {
   count       = local.enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.mq_application_password_ssm_parameter_name)
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.name, var.mq_application_password_ssm_parameter_name)
   value       = local.mq_application_password
   description = "AMQ password for the application user"
   type        = "SecureString"


### PR DESCRIPTION
## what

* added `var.name` to the SSM path

## why

* The params by default are created without a reference to the name of the queue: `/mq/mq_admin_password`.

This solution is merely an option, but the defaults give consumers conflicting SSM params so that's the core need.

## references
