### PR TITLE
fix(tests): available engine version and updated version of the subnets module due to provider 

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -16,7 +16,7 @@ deployment_mode = "ACTIVE_STANDBY_MULTI_AZ"
 
 engine_type = "ActiveMQ"
 
-engine_version = "5.17.6"
+engine_version = "5.18"
 
 # https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-instance-types.html
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -17,8 +17,8 @@ module "subnets" {
 
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
-  igw_id               = module.vpc.igw_id
-  ipv4_cidr_block      = module.vpc.vpc_cidr_block
+  igw_id               = [module.vpc.igw_id]
+  ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled  = false
   nat_instance_enabled = false
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,7 +13,7 @@ module "vpc" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "1.0.0"
+  version = "2.4.2"
 
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -18,7 +18,7 @@ module "subnets" {
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
   igw_id               = module.vpc.igw_id
-  cidr_block           = module.vpc.vpc_cidr_block
+  ipv4_cidr_block      = module.vpc.vpc_cidr_block
   nat_gateway_enabled  = false
   nat_instance_enabled = false
 


### PR DESCRIPTION
Tests are failing because of the `examples/complete/`: https://github.com/cloudposse/terraform-aws-mq-broker/actions/runs/17283152983/job/49055266176

Error: Unsupported argument
  on .terraform/modules/subnets/nat-gateway.tf line 19, in resource "aws_eip" "default":
  19:   vpc   = true

An argument named "vpc" is not expected here.

The newer module of the `cloudposse/dynamic-subnets/aws` addresses it by not using the deprecated `vpc` attribute. 

This will fix tests.