### PR TITLE
feature/ssm-path - avoid multiple mq broker to share with same ssm resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "random_password" "mq_application_password" {
 
 resource "aws_ssm_parameter" "mq_master_username" {
   count       = local.mq_admin_user_enabled && var.ssm_parameters_enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.mq_admin_user_ssm_parameter_name)
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, module.this.id, var.mq_admin_user_ssm_parameter_name)
   value       = local.mq_admin_user
   description = "MQ Username for the admin user"
   type        = "String"
@@ -55,7 +55,7 @@ resource "aws_ssm_parameter" "mq_master_username" {
 
 resource "aws_ssm_parameter" "mq_master_password" {
   count       = local.mq_admin_user_enabled && var.ssm_parameters_enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.mq_admin_password_ssm_parameter_name)
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, module.this.id, var.mq_admin_password_ssm_parameter_name)
   value       = local.mq_admin_password
   description = "MQ Password for the admin user"
   type        = "SecureString"
@@ -65,7 +65,7 @@ resource "aws_ssm_parameter" "mq_master_password" {
 
 resource "aws_ssm_parameter" "mq_application_username" {
   count       = local.enabled && var.ssm_parameters_enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.mq_application_user_ssm_parameter_name)
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, module.this.id, var.mq_application_user_ssm_parameter_name)
   value       = local.mq_application_user
   description = "AMQ username for the application user"
   type        = "String"
@@ -74,7 +74,7 @@ resource "aws_ssm_parameter" "mq_application_username" {
 
 resource "aws_ssm_parameter" "mq_application_password" {
   count       = local.enabled && var.ssm_parameters_enabled ? 1 : 0
-  name        = format(var.ssm_parameter_name_format, var.ssm_path, var.mq_application_password_ssm_parameter_name)
+  name        = format(var.ssm_parameter_name_format, var.ssm_path, module.this.id, var.mq_application_password_ssm_parameter_name)
   value       = local.mq_application_password
   description = "AMQ password for the application user"
   type        = "SecureString"

--- a/variables.tf
+++ b/variables.tf
@@ -115,7 +115,7 @@ variable "ssm_parameters_enabled" {
 variable "ssm_parameter_name_format" {
   type        = string
   description = "SSM parameter name format"
-  default     = "/%s/%s"
+  default     = "/%s/%s/%s"
 }
 
 variable "ssm_path" {


### PR DESCRIPTION
## what

* Updated SSM parameter naming format to include `module.this.id` (**broker name**)  as part of the path.
* Applied the updated naming convention across all MQ-related SSM parameters (admin username/password and application username/password).
* Updated the default value of the `ssm_parameter_name_format` variable to accommodate the new naming structure.

## why

* Ensures SSM parameter names are unique per module instance (multiple MQ brokers), preventing naming collisions when deploying multiple modules .

## references

N/A
